### PR TITLE
Bump go networking version due to discovered vulnerability to XSS

### DIFF
--- a/experiments/grpcalc/go.mod
+++ b/experiments/grpcalc/go.mod
@@ -3,7 +3,7 @@ module demo
 go 1.18
 
 require (
-	golang.org/x/net v0.36.0 // indirect
+	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/sys v0.17.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240227224415-6ceb2ff114de // indirect


### PR DESCRIPTION
Upgrade to go 0.38 which shouldn't expose XSS